### PR TITLE
fix: remove autoprefixer dependency from PostCSS config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,5 @@
 export default {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
   },
 }


### PR DESCRIPTION
- Remove autoprefixer from postcss.config.js to resolve build error
- Keep only tailwindcss plugin for CSS processing
- Resolves 'Cannot find module autoprefixer' error during deployment
- Final fix needed for successful build completion